### PR TITLE
Remove event listener automatically on page change

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,11 @@
+function destroyVue() {
+  this.$destroy();
+  document.removeEventListener('turbolinks:before-cache', destroyVue.bind(this))
+}
+
 var TurbolinksAdapter = {
   beforeMount: function(){
-    document.addEventListener('turbolinks:before-cache', () => {
-      this.$destroy();
-    });
-
+    document.addEventListener('turbolinks:before-cache', destroyVue.bind(this))
     this.$originalEl = this.$el.outerHTML;
   },
   destroyed: function() {


### PR DESCRIPTION
This fixes a bug that happens when the Vue app isn't on the next/previous page. Unbinding the event makes sure that specific event listener is removed cleanly along with the Vue app.