### PR TITLE
Refactor to make a global mixin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # A Turbolinks Adapter for Vue components
 
+vue-turbolinks is a package to allow you to easily add Vue.js components
+to your Turbolinks powered apps. We handle the Turbolinks events to
+properly setup and teardown your Vue components on the page.
+
 To use this in a Rails project with [webpacker](https://github.com/rails/webpacker) support,
 
 ``` bash
@@ -11,14 +15,14 @@ project with `rails new myapp --webpack=vue`. In your `app.vue` file:
 
 ```javascript
 import TurbolinksAdapter from 'vue-turbolinks'
+Vue.use(TurbolinksAdapter)
 
 export default {
   data: function () {
     return {
       message: new Date
     }
-  },
-  mixins: [TurbolinksAdapter]
+  }
 }
 ```
 
@@ -26,12 +30,12 @@ Or if you're just doing this in a regular Javascript file:
 
 ``` javascript
 import TurbolinksAdapter from 'vue-turbolinks';
+Vue.use(TurbolinksAdapter)
 
 document.addEventListener('turbolinks:load', () => {
   var vueapp = new Vue({
     el: "#hello",
     template: '<App/>',
-    mixins: [TurbolinksAdapter],
     components: { App }
   });
 });
@@ -44,6 +48,7 @@ conditionally initialize the Vue app like so:
 
 ``` javascript
 import TurbolinksAdapter from 'vue-turbolinks';
+Vue.use(TurbolinksAdapter)
 
 document.addEventListener('turbolinks:load', () => {
   var element = document.getElementById("hello")
@@ -51,7 +56,6 @@ document.addEventListener('turbolinks:load', () => {
     var vueapp = new Vue({
       el: element,
       template: '<App/>',
-      mixins: [TurbolinksAdapter],
       components: { App }
     });
   }

--- a/index.js
+++ b/index.js
@@ -1,20 +1,30 @@
-function handleVueDestruction(vue) {
-  document.addEventListener('turbolinks:visit', function teardown() {
+function handleVueDestructionOn(turbolinksEvent, vue) {
+  document.addEventListener(turbolinksEvent, function teardown() {
     vue.$destroy();
-    document.removeEventListener('turbolinks:visit', teardown);
+    document.removeEventListener(turbolinksEvent, teardown);
   });
 }
 
-var TurbolinksAdapter = {
-  beforeMount: function() {
-    if (this.$el.parentNode) {
-      handleVueDestruction(this);
-      this.$originalEl = this.$el.outerHTML;
+function plugin(Vue, options) {
+  // Install a global mixin
+  Vue.mixin({
+
+    beforeMount: function() {
+      // If this is the root component, we want to cache the original element contents to replace later
+      // We don't care about sub-components, just the root
+      if (this == this.$root) {
+        handleVueDestructionOn('turbolinks:visit', this);
+        this.$originalEl = this.$el.outerHTML;
+      }
+    },
+
+    destroyed: function() {
+      // We only need to revert the html for the root component
+      if (this == this.$root) {
+        this.$el.outerHTML = this.$originalEl;
+      }
     }
-  },
-  destroyed: function() {
-    this.$el.outerHTML = this.$originalEl;
-  }
+  })
 };
 
-export default TurbolinksAdapter;
+export default plugin;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-turbolinks",
-  "version": "1.1.1",
+  "version": "2.0.0",
   "description": "A Vue mixin to make components work with Turbolinks' cache",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
I was fiddling with this package earlier today and it felt clunky to have to install the mixin for each Vue app on your page (if you use multiple ones). I thought it might be considerably easier to use a plugin instead that could be applied to all Vue apps which simplifies the setup for everything.

The end-user code will now be as simple as this and no longer will require the `mixins: [TurbolinksAdapter]` option to be passed in each time.

```javascript
import TurbolinksAdapter from 'vue-turbolinks'
Vue.use(TurbolinksAdapter)
```

This also can just run a single time and it will be applied to all of Vue apps created afterward.

Give it a try, check for regressions, and let me know what you think!