### PR TITLE
Proposal: Add new app helper for turbolinks apps

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,9 +6,19 @@ function handleVueDestructionOn(turbolinksEvent, vue) {
 }
 
 function plugin(Vue, options) {
-  // Install a global mixin
-  Vue.mixin({
+  // Creates a new Turbolinks enabled Vue app
+  Vue.newTurbolinksApp = function (selector, options, callback) {
+    document.addEventListener("turbolinks:load", function() {
+      const element = document.querySelector(selector);
+      if (element !== null) {
+        var callbackOptions = typeof callback === 'function' && callback(element) || {};
+        var opts = Object.assign({el: element}, options, callbackOptions);
+        return new Vue(opts);
+      }
+    });
+  }
 
+  Vue.mixin({
     beforeMount: function() {
       // If this is the root component, we want to cache the original element contents to replace later
       // We don't care about sub-components, just the root


### PR DESCRIPTION
It's annoying to have all this boiler plate for each Vue app:

``` javascript
import TurbolinksAdapter from 'vue-turbolinks';
Vue.use(TurbolinksAdapter)

document.addEventListener('turbolinks:load', () => {
  var element = document.getElementById("hello")
  if (element != null) {
    var vueapp = new Vue({
      el: element,
      template: '<App/>',
      components: { App }
    });
  }
});
```

This PR adds a helper method to Vue.js that takes care of this for you. It also includes an optional callback to let you preload data from the element if you want.

The above example would be turned into this:

```js
import TurbolinksAdapter from 'vue-turbolinks';
Vue.use(TurbolinksAdapter)

var vueapp = Vue.newTurbolinksApp("#hello", {
  template: '<App/>',
  components: { App }
});
```

This isn't quite ready to merge just yet as it needs some documentation but I wanted to propose this and show the implementation for it to see what you think. 