### PR TITLE
Allow rendering off-document

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ function plugin(Vue, options) {
     beforeMount: function() {
       // If this is the root component, we want to cache the original element contents to replace later
       // We don't care about sub-components, just the root
-      if (this == this.$root) {
+      if (this == this.$root && this.$el) {
         var destroyEvent = this.$options.turbolinksDestroyEvent || 'turbolinks:visit'
         handleVueDestructionOn(destroyEvent, this);
         this.$originalEl = this.$el.outerHTML;


### PR DESCRIPTION
In #17 this guard was put on the `destroyed` callback but I believe it also needs to be applied to the `beforeMount` callback. Vue allows `$mount` to be called without an argument to render off-document. See:

https://v1.vuejs.org/api/#vm-mount

This avoids an error when a component is rendered off-document.