### PR TITLE
fix #31 where error occurs when non-root component destroyed

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ To use the mixin, include it where you setup your component.
 For example, if you used `rails new myapp --webpack=vue` to create your project using
 webpacker, you'll include it in your `hello_vue.js` file:
 
+### Mixin Option 1: Global
+
 ``` javascript
 import TurbolinksAdapter from 'vue-turbolinks';
 Vue.use(TurbolinksAdapter)
@@ -31,6 +33,21 @@ document.addEventListener('turbolinks:load', () => {
   var vueapp = new Vue({
     el: "#hello",
     template: '<App/>',
+    components: { App }
+  });
+});
+```
+
+### Mixin Option 2: Single Component
+
+``` javascript
+import { turbolinksAdapterMixin } from 'vue-turbolinks';
+
+document.addEventListener('turbolinks:load', () => {
+  var vueapp = new Vue({
+    el: "#hello",
+    template: '<App/>',
+    mixins: [turbolinksAdapterMixin],
     components: { App }
   });
 });

--- a/index.js
+++ b/index.js
@@ -16,15 +16,12 @@ function plugin(Vue, options) {
         var destroyEvent = this.$options.turbolinksDestroyEvent || 'turbolinks:visit'
         handleVueDestructionOn(destroyEvent, this);
         this.$originalEl = this.$el.outerHTML;
+        // register root hook to restore original element on destroy
+        this.$once('hook:destroyed', function() {
+          this.$el.outerHTML = this.$originalEl
+        });
       }
     },
-
-    destroyed: function() {
-      // We only need to revert the html for the root component
-      if (this == this.$root && this.$el) {
-        this.$el.outerHTML = this.$originalEl;
-      }
-    }
   })
 };
 

--- a/index.js
+++ b/index.js
@@ -15,10 +15,10 @@ function plugin(Vue, options) {
       if (this == this.$root && this.$el) {
         var destroyEvent = this.$options.turbolinksDestroyEvent || 'turbolinks:visit'
         handleVueDestructionOn(destroyEvent, this);
-        this.$originalEl = this.$el.outerHTML;
+        this.$turbolinksCachedHTML = this.$el.outerHTML;
         // register root hook to restore original element on destroy
         this.$once('hook:destroyed', function() {
-          this.$el.outerHTML = this.$originalEl
+          this.$el.outerHTML = this.$turbolinksCachedHTML
         });
       }
     },

--- a/index.js
+++ b/index.js
@@ -1,28 +1,31 @@
-function handleVueDestructionOn(turbolinksEvent, vue) {
+function handleVueDestruction(vue) {
+  var turbolinksEvent = vue.$options.turbolinksDestroyEvent || 'turbolinks:visit';
   document.addEventListener(turbolinksEvent, function teardown() {
     vue.$destroy();
     document.removeEventListener(turbolinksEvent, teardown);
   });
 }
 
-function plugin(Vue, options) {
-  // Install a global mixin
-  Vue.mixin({
-
-    beforeMount: function() {
-      // If this is the root component, we want to cache the original element contents to replace later
-      // We don't care about sub-components, just the root
-      if (this == this.$root && this.$el) {
-        var destroyEvent = this.$options.turbolinksDestroyEvent || 'turbolinks:visit'
-        handleVueDestructionOn(destroyEvent, this);
-        this.$turbolinksCachedHTML = this.$el.outerHTML;
-        // register root hook to restore original element on destroy
-        this.$once('hook:destroyed', function() {
-          this.$el.outerHTML = this.$turbolinksCachedHTML
-        });
-      }
-    },
-  })
+var turbolinksAdapterMixin = {
+  beforeMount: function() {
+    // If this is the root component, we want to cache the original element contents to replace later
+    // We don't care about sub-components, just the root
+    if (this === this.$root && this.$el) {
+      handleVueDestruction(this);
+      // cache original element
+      this.$turbolinksCachedHTML = this.$el.outerHTML;
+      // register root hook to restore original element on destroy
+      this.$once('hook:destroyed', function() {
+        this.$el.outerHTML = this.$turbolinksCachedHTML
+      });
+    }
+  }
 };
 
+function plugin(Vue, options) {
+  // Install a global mixin
+  Vue.mixin(turbolinksAdapterMixin)
+}
+
+export { turbolinksAdapterMixin };
 export default plugin;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-turbolinks",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "A Vue mixin to make components work with Turbolinks' cache",
   "main": "index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-turbolinks",
-  "version": "2.0.5",
+  "version": "2.1.0",
   "description": "A Vue mixin to make components work with Turbolinks' cache",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
also refactor mixin to allow global and single component mixin patterns as discussed in #31