### PR TITLE
Fix to export `turbolinksAdapterMixin`

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,5 +38,5 @@ function defaultEvent() {
   return 'turbolinks:visit';
 }
 
-export { Mixin };
+export { Mixin as turbolinksAdapterMixin };
 export default plugin;


### PR DESCRIPTION
Since 396fb1a1734365f0eff8dafc25e4f10c8694d95c, ["Mixin Option 2: Single Component"](https://github.com/jeffreyguenther/vue-turbolinks/tree/v2.2.0#mixin-option-2-single-component) has been broken.

```
"export 'turbolinksAdapterMixin' was not found in 'vue-turbolinks'
```

To keep v2.1.0's behavior, let back the export module name.